### PR TITLE
Add MultiAssetTransfer method and fix typo

### DIFF
--- a/demo/Program.cs
+++ b/demo/Program.cs
@@ -129,6 +129,49 @@ namespace demo
 
         }
 
+        public static async Task MultiAssetTransferDemo()
+        {
+            Console.WriteLine("MultiAssetTransfer Demo");
+
+            var kp = new KleverProvider(new NetworkConfig(Network.TestNet));
+            var wallet = new Wallet("hex-private-key");
+            var acc = wallet.GetAccount();
+
+            try
+            {
+                await acc.Sync(kp);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("account does not exist in blockchain yet: {0}", e.ToString());
+                return;
+            }
+
+            Console.WriteLine("Address: {0}", acc.Address.Bech32);
+            Console.WriteLine("Balance: {0}", acc.Balance);
+
+            // Send 2 different assets in one transaction
+            var transfers = new List<MultiAssetTx>
+            {
+                new MultiAssetTx("klv1receiver1...", 100m, "KLV", 6),
+                new MultiAssetTx("klv1receiver2...", 50m, "KFI", 6)
+            };
+
+            try
+            {
+                var tx = await kp.MultiAssetTransfer(acc.Address.Bech32, acc.Nonce, transfers);
+                var decoded = await kp.Decode(tx);
+                var signature = wallet.SignHex(decoded.Hash);
+                tx.AddSignature(signature);
+                var broadcastResult = await kp.Broadcast(tx);
+                Console.WriteLine("Broadcast result: {0}", broadcastResult.String());
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error sending: {0}", e.ToString());
+                return;
+            }
+        }
         public static async Task Main(string[] args)
         {
 

--- a/klever.net.sln
+++ b/klever.net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.810.20
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36717.8 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "demo", "demo\demo.csproj", "{3F8DCFD5-BC6F-4FDA-A8DC-93441E5B4209}"
 EndProject
@@ -10,10 +10,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kleversdk.Tests", "kleversdk.Tests\kleversdk.Tests.csproj", "{47290DD7-82BC-4786-BE3D-132992D70F7A}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		kleversdk\kleversdk.projitems*{0611bc38-01e5-42f5-9406-132b4e63ad90}*SharedItemsImports = 13
-		kleversdk\kleversdk.projitems*{3f8dcfd5-bc6f-4fda-a8dc-93441e5b4209}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|anycpu = Debug|anycpu
 		Release|anycpu = Release|anycpu

--- a/kleversdk/provider/Dto/MultiAssetTx.cs
+++ b/kleversdk/provider/Dto/MultiAssetTx.cs
@@ -1,0 +1,22 @@
+namespace kleversdk.provider.Dto
+{
+    /// <summary>
+    /// Represents a single transfer in a multi-asset transaction
+    /// Used with MultiAssetTransfer to send different assets in one transaction
+    /// </summary>
+    public class MultiAssetTx
+    {
+        public string Address { get; set; }
+        public decimal Amount { get; set; }
+        public string Asset { get; set; }
+        public int Precision { get; set; }
+        
+        public MultiAssetTx(string address, decimal amount, string asset, int precision)
+        {
+            Address = address;
+            Amount = amount;
+            Asset = asset;
+            Precision = precision;
+        }
+    }
+}

--- a/kleversdk/provider/Dto/TransactionDto.cs
+++ b/kleversdk/provider/Dto/TransactionDto.cs
@@ -66,7 +66,7 @@ namespace kleversdk.provider.Dto
         public Transaction Result { get; set; }
     }
 
-    public class ToBoradcast
+    public class ToBroadcast
     {
         public Transaction Tx { get; set; }
 

--- a/kleversdk/provider/IKleverProvider.cs
+++ b/kleversdk/provider/IKleverProvider.cs
@@ -17,6 +17,7 @@ namespace kleversdk.provider
         Task<TransactionAPI> Decode(Transaction tx);
         Task<Transaction> Send(string fromAddr, long nonce, string toAddr, float amount, string kda = "KLV", string kdaFee = "", long permID = 0);
         Task<Transaction> SendWithMessage(string fromAddr, long nonce, string toAddr, float amount, string message, string kda = "KLV", string kdaFee = "", long permID = 0);
+        Task<Transaction> MultiAssetTransfer(string fromAddr,long nonce,List<MultiAssetTx> transfers,string kdaFee = "",byte[][] messageData = null, long permID = 0);
         Task<provider.Dto.Transaction> Claim(string fromAddr, long nonce, int claimType, string id = "KLV", string kdaFee = "", long permID = 0);
         Task<provider.Dto.Transaction> Freeze(string fromAddr, long nonce, float Amount, string kda = "KLV", string kdaFee = "", long permID = 0);
         Task<provider.Dto.Transaction> Unfreeze(string fromAddr, long nonce, string BucketID, string kda = "KLV", string kdaFee = "", long permID = 0);

--- a/kleversdk/provider/KleverProvider.cs
+++ b/kleversdk/provider/KleverProvider.cs
@@ -323,27 +323,35 @@ namespace kleversdk.provider
             return await this.PrepareTransaction(data);
         }
 
-        public async Task<Transaction> MultiAssetTransfer(
-    string fromAddr,
-    long nonce,
-    List<MultiAssetTx> transfers,
-    string kdaFee = "",
-    byte[][] messageData = null,
-    long permID = 0)
+        public async Task<Transaction> MultiAssetTransfer(string fromAddr, long nonce, List<MultiAssetTx> transfers, string kdaFee = "", byte[][] messageData = null, long permID = 0)
         {
             var contracts = new List<IContract>();
 
             for (int i = 0; i < transfers.Count; i++)
             {
+                // Sanity checks
+                if (string.IsNullOrEmpty(transfers[i].Address))
+                {
+                    throw new ArgumentException($"Transfer {i}: Address cannot be empty");
+                }
+
+                if (transfers[i].Amount <= 0)
+                {
+                    throw new ArgumentException($"Transfer {i}: Amount must be greater than 0");
+                }
+
+                if (transfers[i].Precision < 0)
+                {
+                    throw new ArgumentException($"Transfer {i}: Precision cannot be negative");
+                }
+
                 string kda = transfers[i].Asset.ToUpper();
 
                 // Convert amount with specified precision
-                // FIX: Cast Math.Pow to decimal
                 long parsedAmount = Convert.ToInt64(
                     transfers[i].Amount * (decimal)Math.Pow(10, transfers[i].Precision)
                 );
 
-                // Add transfer contract
                 contracts.Add(new TransferContract(
                     transfers[i].Address,
                     parsedAmount,
@@ -351,7 +359,6 @@ namespace kleversdk.provider
                 ));
             }
 
-            // Build request with all contracts
             var data = BuildRequest(
                 TXContract_ContractType.TXContract_TransferContractType,
                 fromAddr,
@@ -364,6 +371,7 @@ namespace kleversdk.provider
 
             return await PrepareTransaction(data);
         }
+
         public SendRequest BuildRequest(TXContract_ContractType cType, string fromAddress, long nonce, List<IContract> contracts, byte[][] message = null, string kdaFee = "", long permID = 0)
         {
             if (contracts.Count == 0 || contracts.Count > 20)

--- a/kleversdk/provider/KleverProvider.cs
+++ b/kleversdk/provider/KleverProvider.cs
@@ -323,6 +323,47 @@ namespace kleversdk.provider
             return await this.PrepareTransaction(data);
         }
 
+        public async Task<Transaction> MultiAssetTransfer(
+    string fromAddr,
+    long nonce,
+    List<MultiAssetTx> transfers,
+    string kdaFee = "",
+    byte[][] messageData = null,
+    long permID = 0)
+        {
+            var contracts = new List<IContract>();
+
+            for (int i = 0; i < transfers.Count; i++)
+            {
+                string kda = transfers[i].Asset.ToUpper();
+
+                // Convert amount with specified precision
+                // FIX: Cast Math.Pow to decimal
+                long parsedAmount = Convert.ToInt64(
+                    transfers[i].Amount * (decimal)Math.Pow(10, transfers[i].Precision)
+                );
+
+                // Add transfer contract
+                contracts.Add(new TransferContract(
+                    transfers[i].Address,
+                    parsedAmount,
+                    kda
+                ));
+            }
+
+            // Build request with all contracts
+            var data = BuildRequest(
+                TXContract_ContractType.TXContract_TransferContractType,
+                fromAddr,
+                nonce,
+                contracts,
+                messageData,
+                kdaFee,
+                permID
+            );
+
+            return await PrepareTransaction(data);
+        }
         public SendRequest BuildRequest(TXContract_ContractType cType, string fromAddress, long nonce, List<IContract> contracts, byte[][] message = null, string kdaFee = "", long permID = 0)
         {
             if (contracts.Count == 0 || contracts.Count > 20)
@@ -370,7 +411,7 @@ namespace kleversdk.provider
 
         public async Task<BroadcastResult> Broadcast(Transaction tx)
         {
-            var data = new ToBoradcast { Tx = tx }.String();
+            var data = new ToBroadcast { Tx = tx }.String();
             var dataContent = new StringContent(data, Encoding.UTF8, "application/json");
             var response = await _nodeClient.PostAsync($"transaction/broadcast", dataContent);
 


### PR DESCRIPTION
## Summary
Add MultiAssetTransfer method to enable sending multiple different assets in a single transaction.

## Changes
- Add `MultiAssetTx` DTO class in `kleversdk/provider/Dto/`
- Add `MultiAssetTransfer` method to `KleverProvider`
- Add interface definition to `IKleverProvider`
- Add demo example in `demo/MainClass.cs`
- Fix typo: boradcast → broadcast

## Use Case
Enables mixing KLV and various KDA tokens in one transaction (e.g., validator distributions with fees in KLV and rewards in other assets).

## Testing
Tested in production validator distribution system with 150+ delegators.